### PR TITLE
Bad value for attribute "width" in contact.html

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -44,7 +44,7 @@
 
     <!-- Page Content -->
     <section style="background: white">
-         <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSezCjvM6k-uylT_kG1LpLHWbQy-Z3GSeMT7nLCWf-Drj3HsQg/viewform?embedded=true" width="100%" height="947" frameborder="0" marginheight="0" marginwidth="0" align="middle">Loading...</iframe>
+         <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSezCjvM6k-uylT_kG1LpLHWbQy-Z3GSeMT7nLCWf-Drj3HsQg/viewform?embedded=true" width="100" height="947" frameborder="0" marginheight="0" marginwidth="0" align="middle">Loading...</iframe>
     </section>
 
   </body>


### PR DESCRIPTION
This attribute expects a digit, not a percentage. This is just a minor change just to comply with HTML 5.2 standards.
-edit: on second thought this digit would actually  be much larger then 100, since it represents the width in pixels. 